### PR TITLE
Fix typos and literal/variable mistakes in building the json for the …

### DIFF
--- a/R/hdi_json.R
+++ b/R/hdi_json.R
@@ -92,17 +92,17 @@ paste0('
 
 hive_json = function(hiveServer, hiveDB, hiveUser, hivePassword) {
   paste0('
-  ",hive-site": {
-    "javax.jdo.option.ConnectionDrivername": "com.microsoft.sqlserver.jdbc.SQLServerDriver",
+  ,"hive-site": {
+    "javax.jdo.option.ConnectionDriverName": "com.microsoft.sqlserver.jdbc.SQLServerDriver",
     "javax.jdo.option.ConnectionURL":"jdbc:sqlserver://', hiveServer, ';database=', hiveDB, ';encrypt=true;trustServerCertificate=true;create=false;loginTimeout=300",
-  "javax.jdo.option.ConnectionUsername":"', hiveUser, '",
+  "javax.jdo.option.ConnectionUserName":"', hiveUser, '",
   "javax.jdo.option.ConnectionPassword":"', hivePassword, '"
   },
   "hive-env": {
     "hive_database": "Existing MSSQL Server database with SQL authentication",
-    "hive_database_name": "HIVEDB",
+    "hive_database_name": "', hiveDB, '",
     "hive_database_type": "mssql",
-    "hive_existing_mssql_server_database": "HIVEDB",
+    "hive_existing_mssql_server_database": "', hiveDB, '",
     "hive_existing_mssql_server_host":"', hiveServer, '",
     "hive_hostname":"', hiveServer,'"
   }'


### PR DESCRIPTION
…SQL Hive metastore.

- Moved misplaced comma in "hive-site" tag.
- Corrected "javax.jdo.option.ConnectionDriver**n**ame" to "javax.jdo.option.ConnectionDriver**N**ame"
- Corrected "javax.jdo.option.ConnectionUser**n**ame" to "javax.jdo.option.ConnectionUser**N**ame"
- Replaced "HIVEDB" literal with hiveDB value specified in azureCreateHDI function call.