### PR TITLE
Fix for updateAzureActiveContext to pass when azureActiveContext is set to NULL

### DIFF
--- a/R/internal.R
+++ b/R/internal.R
@@ -165,12 +165,14 @@ refreshStorageKey <- function(azureActiveContext, storageAccount, resourceGroup)
 
 updateAzureActiveContext <- function(x, storageAccount, storageKey, resourceGroup, container, blob, directory) {
   # updates the active azure context in place
-  assert_that(is.azureActiveContext(x))
-  if (!missing(storageAccount)) x$storageAccount <- storageAccount
-  if (!missing(resourceGroup))  x$resourceGroup  <- resourceGroup
-  if (!missing(storageKey))     x$storageKey     <- storageKey
-  if (!missing(container)) x$container <- container
-  if (!missing(blob)) x$blob <- blob
-  if (!missing(directory)) x$directory <- directory
+  if (!is.null(x)) {
+    assert_that(is.azureActiveContext(x))
+    if (!missing(storageAccount)) x$storageAccount <- storageAccount
+    if (!missing(resourceGroup))  x$resourceGroup  <- resourceGroup
+    if (!missing(storageKey))     x$storageKey     <- storageKey
+    if (!missing(container)) x$container <- container
+    if (!missing(blob)) x$blob <- blob
+    if (!missing(directory)) x$directory <- directory
+  }
   TRUE
 }


### PR DESCRIPTION
This change fixes issue #86. 

When a `NULL` value is passed for the `azureActiveContext` argument to blob storage functions, the assertions and updates in `updateAzureActiveContext` are unnecessary and throw an error.