### PR TITLE
Fix incorrect content length calculation for raw vectors in Storage API

### DIFF
--- a/R/AzureBlob.R
+++ b/R/AzureBlob.R
@@ -338,7 +338,7 @@ azurePutBlob <- function(azureActiveContext, blob, contents = "", file = "",
   stopWithAzureError(r)
 
   updateAzureActiveContext(azureActiveContext, blob = blob)
-  message("blob ", blob, " saved: ", nchar(contents), " bytes written")
+  message("blob ", blob, " saved: ", getContentSize(contents), " bytes written")
   TRUE
 }
 

--- a/R/internal.R
+++ b/R/internal.R
@@ -26,7 +26,7 @@ extractUrlArguments <- function(x) {
 }
 
 callAzureStorageApi <- function(url, verb = "GET", storageKey, storageAccount,
-                   headers = NULL, container = NULL, CMD, size = nchar(content), contenttype = NULL,
+                   headers = NULL, container = NULL, CMD, size = getContentSize(content), contenttype = NULL,
                    content = NULL,
                    verbose = FALSE) {
   dateStamp <- httr::http_date(Sys.time())
@@ -50,16 +50,22 @@ callAzureStorageApi <- function(url, verb = "GET", storageKey, storageAccount,
                                     ),
     verbosity),
   "PUT" = PUT(url, add_headers(.headers = c(Authorization = azToken,
-                                         `Content-Length` = nchar(content),
+                                         `Content-Length` = size,
                                          `x-ms-version` = "2015-04-05",
                                          `x-ms-date` = dateStamp,
                                          `x-ms-blob-type` = "Blockblob",
-                                         `Content-type` = "text/plain; charset=UTF-8")),
+                                         `Content-type` = contenttype)),
            body = content,
     verbosity)
   )
 }
 
+getContentSize<- function(obj) {
+    switch(class(obj),
+         "raw" = length(obj),
+         "character" = nchar(obj),
+         nchar(obj))
+}
 
 createAzureStorageSignature <- function(url, verb, 
   key, storageAccount, container = NULL,

--- a/tests/testthat/test-2-resources.R
+++ b/tests/testthat/test-2-resources.R
@@ -123,6 +123,9 @@ test_that("Can put, list, get and delete a blob", {
   expect_true(res)
   res <- azurePutBlob(asc, blob = "foo", contents = "foo", container = "tempcontainer")
   expect_true(res)
+  #test raw vectors as well
+  res <- azurePutBlob(asc, blob = "raw", contents = serialize("bar",connection = NULL), container = "tempcontainer")
+  expect_true(res)
 
   res <- azureListStorageBlobs(asc, container = "tempcontainer")
   expect_is(res, "data.frame")


### PR DESCRIPTION
The previous PR (https://github.com/Microsoft/AzureSMR/pull/93) had some other pending changes merged in, I've raised a separate PR to make this a bit cleaner. What is the status of the other pending PR's? Specifically our use case requires the fixes from https://github.com/Microsoft/AzureSMR/pull/91


Simple test case added as well

