### PR TITLE
Upgrade Azure Storage API version to 2017-04-17

### DIFF
--- a/R/internal.R
+++ b/R/internal.R
@@ -45,13 +45,13 @@ callAzureStorageApi <- function(url, verb = "GET", storageKey, storageAccount,
   switch(verb, 
   "GET" = GET(url, add_headers(.headers = c(Authorization = azToken,
                                     `Content-Length` = "0",
-                                    `x-ms-version` = "2015-04-05",
+                                    `x-ms-version` = "2017-04-17",
                                     `x-ms-date` = dateStamp)
                                     ),
     verbosity),
   "PUT" = PUT(url, add_headers(.headers = c(Authorization = azToken,
                                          `Content-Length` = size,
-                                         `x-ms-version` = "2015-04-05",
+                                         `x-ms-version` = "2017-04-17",
                                          `x-ms-date` = dateStamp,
                                          `x-ms-blob-type` = "Blockblob",
                                          `Content-type` = contenttype)),
@@ -76,9 +76,9 @@ createAzureStorageSignature <- function(url, verb,
   }
 
   arg1 <- if (length(headers)) {
-    paste0(headers, "\nx-ms-date:", dateStamp, "\nx-ms-version:2015-04-05")
+    paste0(headers, "\nx-ms-date:", dateStamp, "\nx-ms-version:2017-04-17")
   } else {
-    paste0("x-ms-date:", dateStamp, "\nx-ms-version:2015-04-05")
+    paste0("x-ms-date:", dateStamp, "\nx-ms-version:2017-04-17")
   }
 
   arg2 <- paste0("/", storageAccount, "/", container, CMD)
@@ -100,7 +100,7 @@ azure_storage_header <- function(shared_key, date = x_ms_date(), content_length 
   headers <- c(
       Authorization = shared_key,
       `Content-Length` = as.character(content_length),
-      `x-ms-version` = "2015-04-05",
+      `x-ms-version` = "2017-04-17",
       `x-ms-date` = date
   )
   add_headers(.headers = headers)
@@ -159,9 +159,9 @@ getSig <- function(azureActiveContext, url, verb, key, storageAccount,
                    date = x_ms_date(), verbose = FALSE) {
 
   arg1 <- if (length(headers)) {
-    paste0(headers, "\nx-ms-date:", date, "\nx-ms-version:2015-04-05")
+    paste0(headers, "\nx-ms-date:", date, "\nx-ms-version:2017-04-17")
   } else {
-    paste0("x-ms-date:", date, "\nx-ms-version:2015-04-05")
+    paste0("x-ms-date:", date, "\nx-ms-version:2017-04-17")
   }
 
   arg2 <- paste0("/", storageAccount, "/", container, CMD)


### PR DESCRIPTION
The current client storage api version in the library is a bit outdated and doesn't support single blockblob sizes of > 64MB (the latest one supports 100MB blobs). 

Updating the version header will allow for this feature.

There doesn't seem to be any features which have been removed in the later api version
