### PR TITLE
Fixed undefined instance_resource issue

### DIFF
--- a/tests/testthat/test-9-cost.R
+++ b/tests/testthat/test-9-cost.R
@@ -6,8 +6,11 @@
 
 if (interactive()) library("testthat")
 
-settingsfile <- find_config_json()
-config <- read.AzureSMR.config(settingsfile)
+# settingsfile <- find_config_json()
+# config <- read.AzureSMR.config(settingsfile)
+
+settingsfile <- getOption("AzureSMR.config")
+config <- read.AzureSMR.config()
 
 # setup.
 


### PR DESCRIPTION
If `instance` parameter is given in the `azureDataConsumption` function and it is not an empty string, the function will retrieve cost consumption records for Azure instance with the instance name, otherwise, it returns records for all instances under the subscription. 